### PR TITLE
Allow che-cli <filename>

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,13 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	_, _, err := rootCmd.Find(os.Args[1:])
+
+	if err != nil && os.Args[1] != "help" {
+		args := append([]string{"open"}, os.Args[1:]...)
+		rootCmd.SetArgs(args)
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
This CLI tool only has `open` command.

I'm happy if it can be used without `open` prefix like `code` command.

https://code.visualstudio.com/docs/editor/command-line#_opening-files-and-folders